### PR TITLE
Fix MS Authenticator Entropy Request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msal"
 description = "Microsoft Compatible Authentication Library for Rust"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = [
     "David Mulder <dmulder@suse.com>"


### PR DESCRIPTION
The BeginAuth needs to be handled prior to sending the prompt, otherwise we don't have the Entropy request required by the MS Authenticator app.